### PR TITLE
Update .bowerrc

### DIFF
--- a/rest_api/.bowerrc
+++ b/rest_api/.bowerrc
@@ -1,3 +1,4 @@
 {
-    "directory": "src/main/webapp/bower_components"
+    "directory": "src/main/webapp/bower_components",
+    "allow_root": true
 }


### PR DESCRIPTION
.bowerrc is updated to avoid errors happening due to running bower as root user while ./gradlew is executed. "allow_root": true added to the file to solve the issue.