### PR TITLE
Topic based filtering to retrieve data from sensors

### DIFF
--- a/rest_api/.jhipster/SensorData.json
+++ b/rest_api/.jhipster/SensorData.json
@@ -19,6 +19,10 @@
             "fieldName": "timestamp",
             "fieldType": "ZonedDateTime",
             "fieldValidateRules": []
+        },
+        {
+            "fieldName": "topic",
+            "fieldType": "String"
         }
     ],
     "changelogDate": "20160628155140",

--- a/rest_api/src/main/java/com/scorelab/ioe/broker/BrokerMessageListener.java
+++ b/rest_api/src/main/java/com/scorelab/ioe/broker/BrokerMessageListener.java
@@ -43,7 +43,7 @@ public class BrokerMessageListener implements MessageListener {
 
             Sensor sensor = sensorRepository.findBySensorId(sensorData.getSensorId());
             // TODO - Read TTL value
-            databaseService.insertData(sensorData.getSensorId(), sensorData.getData(), sensorData.getDescription(), utcTime, StoreTypes.valueOf(sensor.getStoreType()), 0);
+            databaseService.insertData(sensorData.getSensorId(), sensorData.getData(), sensorData.getDescription(), utcTime, StoreTypes.valueOf(sensor.getStoreType()), sensorData.getTopic(), 0);
 
             System.out.println("Received message: " + textMessage.getText());
         } catch (JMSException e) {

--- a/rest_api/src/main/java/com/scorelab/ioe/domain/SensorData.java
+++ b/rest_api/src/main/java/com/scorelab/ioe/domain/SensorData.java
@@ -31,6 +31,9 @@ public class SensorData implements Serializable {
     @Column(name = "timestamp")
     private ZonedDateTime timestamp;
 
+    @Column(name = "topic")
+    private String topic;
+
     public Long getId() {
         return id;
     }
@@ -71,6 +74,14 @@ public class SensorData implements Serializable {
         this.timestamp = timestamp;
     }
 
+    public String getTopic() {
+        return topic;
+    }
+
+    public void setTopic(String topic) {
+        this.topic = topic;
+    }
+
     @Override
     public boolean equals(Object o) {
         if (this == o) {
@@ -99,6 +110,7 @@ public class SensorData implements Serializable {
             ", data='" + data + "'" +
             ", description='" + description + "'" +
             ", timestamp='" + timestamp + "'" +
+            ", topic='" + topic + "'" +
             '}';
     }
 }

--- a/rest_api/src/main/java/com/scorelab/ioe/service/CassandraService.java
+++ b/rest_api/src/main/java/com/scorelab/ioe/service/CassandraService.java
@@ -116,6 +116,28 @@ public class CassandraService implements SensorDataRepositoryService {
     }
 
     @Override
+    public List<String> readData(Long sensorId, String topic) {
+        String tableName = returnSensorTableName(sensorId);
+        List<String> results = new ArrayList<>();
+
+        Statement statement = QueryBuilder
+            .select()
+            .raw("JSON *")
+            .from(ioeConfiguration.getCassandra().getCassandraKeyspace(), tableName);
+
+        // TODO - Add topic field to sensorData and check
+
+        ResultSet rs = session.execute(statement);
+
+
+        for (Row row : rs) {
+            results.add(row.getString(0));
+        }
+
+        return results;
+    }
+
+    @Override
     public List<String> readData(Long sensorId, List<LocalDate> dates) {
         String tableName = returnSensorTableName(sensorId);
         List<String> results = new ArrayList<>();

--- a/rest_api/src/main/java/com/scorelab/ioe/service/SensorDataRepositoryService.java
+++ b/rest_api/src/main/java/com/scorelab/ioe/service/SensorDataRepositoryService.java
@@ -19,5 +19,7 @@ public interface SensorDataRepositoryService {
 
     public List<String> readData(Long sensorId);
 
+    public List<String> readData(Long sensorId, String topic);
+
     public List<String> readData(Long sensorId, List<LocalDate> dates);
 }

--- a/rest_api/src/main/java/com/scorelab/ioe/service/SensorDataRepositoryService.java
+++ b/rest_api/src/main/java/com/scorelab/ioe/service/SensorDataRepositoryService.java
@@ -15,7 +15,7 @@ public interface SensorDataRepositoryService {
 
     public void createSensorTable(Long sensorId, StoreTypes storeType);
 
-    public void insertData(Long sensorId, String data, String description, ZonedDateTime timestamp, StoreTypes storeType, int ttlValue);
+    public void insertData(Long sensorId, String data, String description, ZonedDateTime timestamp, StoreTypes storeType, String topic, int ttlValue);
 
     public List<String> readData(Long sensorId);
 

--- a/rest_api/src/main/java/com/scorelab/ioe/web/rest/SensorResource.java
+++ b/rest_api/src/main/java/com/scorelab/ioe/web/rest/SensorResource.java
@@ -180,6 +180,21 @@ public class SensorResource {
     }
 
     /**
+     * GET /sensors/:id
+     * Return all sensor data
+     *
+     * @param id of the sensor to insert payload
+     * @throws URISyntaxException if the Location URI syntax is incorrect
+     */
+    @RequestMapping(value = "/sensors/{id}/{topic}/data",
+        method = RequestMethod.GET,
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @Timed
+    public List<String> GetSensorPayloadbyTopic(@PathVariable Long id, @PathVariable String topic){
+        return databaseService.readData(id, topic);
+    }
+
+    /**
      * GET /sensors/:id/data
      * Return all sensor data by given dates
      *

--- a/rest_api/src/main/java/com/scorelab/ioe/web/rest/SensorResource.java
+++ b/rest_api/src/main/java/com/scorelab/ioe/web/rest/SensorResource.java
@@ -161,7 +161,7 @@ public class SensorResource {
 
         Sensor sensor = sensorRepository.findBySensorId(sensorData.getSensorId());
         // TODO - Read TTL value
-        databaseService.insertData(sensorData.getSensorId(), sensorData.getData(), sensorData.getDescription(), utcTime, StoreTypes.valueOf(sensor.getStoreType()), 0);
+        databaseService.insertData(sensorData.getSensorId(), sensorData.getData(), sensorData.getDescription(), utcTime, StoreTypes.valueOf(sensor.getStoreType()), sensorData.getTopic(), 0);
     }
 
     /**
@@ -181,7 +181,7 @@ public class SensorResource {
 
     /**
      * GET /sensors/:id
-     * Return all sensor data
+     * Return all sensor data by topic
      *
      * @param id of the sensor to insert payload
      * @throws URISyntaxException if the Location URI syntax is incorrect

--- a/rest_api/src/main/webapp/app/entities/sensor-data/sensor-data-detail.html
+++ b/rest_api/src/main/webapp/app/entities/sensor-data/sensor-data-detail.html
@@ -20,6 +20,10 @@
         <dd>
             <span>{{vm.sensorData.timestamp | date:'medium'}}</span>
         </dd>
+        <dt><span translate="ioeApp.sensorData.topic">Topic</span></dt>
+        <dd>
+            <span>{{vm.sensorData.topic}}</span>
+        </dd>
     </dl>
 
     <button type="submit"

--- a/rest_api/src/main/webapp/app/entities/sensor-data/sensor-data-dialog.html
+++ b/rest_api/src/main/webapp/app/entities/sensor-data/sensor-data-dialog.html
@@ -41,6 +41,12 @@
                     </span>
                 </div>
         </div>
+        <div class="form-group">
+            <label class="control-label" translate="ioeApp.sensorData.topic" for="field_topic">Topic</label>
+            <input type="text" class="form-control" name="topic" id="field_topic"
+                    ng-model="vm.sensorData.topic"
+                     />
+        </div>
 
     </div>
     <div class="modal-footer">

--- a/rest_api/src/main/webapp/app/entities/sensor-data/sensor-data.html
+++ b/rest_api/src/main/webapp/app/entities/sensor-data/sensor-data.html
@@ -23,6 +23,7 @@
                     <th><span translate="ioeApp.sensorData.data">Data</span></th>
                     <th><span translate="ioeApp.sensorData.description">Description</span></th>
                     <th><span translate="ioeApp.sensorData.timestamp">Timestamp</span></th>
+                    <th><span translate="ioeApp.sensorData.topic">Topic</span></th>
                     <th></th>
                 </tr>
             </thead>
@@ -33,6 +34,7 @@
                     <td>{{sensorData.data}}</td>
                     <td>{{sensorData.description}}</td>
                     <td>{{sensorData.timestamp | date:'medium'}}</td>
+                    <td>{{sensorData.topic}}</td>
                     <td class="text-right">
                         <div class="btn-group flex-btn-group-container">
                             <button type="submit"

--- a/rest_api/src/main/webapp/app/entities/sensor-data/sensor-data.state.js
+++ b/rest_api/src/main/webapp/app/entities/sensor-data/sensor-data.state.js
@@ -75,6 +75,7 @@
                                 data: null,
                                 description: null,
                                 timestamp: null,
+                                topic: null,
                                 id: null
                             };
                         }


### PR DESCRIPTION
Topic based filtering has to be implemented on sensorData when retrieving data from sensors. The topic can be specified as in `http://127.0.0.1:8080/api/sensors/{id}/{topic}/data`. An extra field is added to sensorData for topic and is checked in Cassandra for a sensorData with specific topic for each request. 