### PR TITLE
Topic field added to subscription entity

### DIFF
--- a/rest_api/.jhipster/Subscription.json
+++ b/rest_api/.jhipster/Subscription.json
@@ -27,6 +27,11 @@
       "fieldId": 1,
       "fieldName": "subscriptionId",
       "fieldType": "Long"
+    },
+    {
+      "fieldId": 2,
+      "fieldName": "topics",
+      "fieldType": "String"
     }
   ],
   "changelogDate": "20160605135943",

--- a/rest_api/.jhipster/Subscription.json
+++ b/rest_api/.jhipster/Subscription.json
@@ -30,7 +30,7 @@
     },
     {
       "fieldId": 2,
-      "fieldName": "topics",
+      "fieldName": "topicFilter",
       "fieldType": "String"
     }
   ],

--- a/rest_api/src/main/java/com/scorelab/ioe/domain/Subscription.java
+++ b/rest_api/src/main/java/com/scorelab/ioe/domain/Subscription.java
@@ -21,8 +21,8 @@ public class Subscription implements Serializable {
     @Column(name = "subscription_id")
     private Long subscriptionId;
 
-    @Column(name = "topics")
-    private String topics;
+    @Column(name = "topic_filter")
+    private String topicFilter;
 
     @ManyToOne
     private Device device;
@@ -49,12 +49,12 @@ public class Subscription implements Serializable {
         this.subscriptionId = subscriptionId;
     }
 
-    public String getTopics() {
-        return topics;
+    public String getTopicFilter() {
+        return topicFilter;
     }
 
-    public void setTopics(String topics) {
-        this.topics = topics;
+    public void setTopicFilter(String topicFilter) {
+        this.topicFilter = topicFilter;
     }
 
     public Device getDevice() {
@@ -106,7 +106,7 @@ public class Subscription implements Serializable {
         return "Subscription{" +
             "id=" + id +
             ", subscriptionId='" + subscriptionId + "'" +
-            ", topics='" + topics + "'" +
+            ", topicFilter='" + topicFilter + "'" +
             '}';
     }
 }

--- a/rest_api/src/main/java/com/scorelab/ioe/domain/Subscription.java
+++ b/rest_api/src/main/java/com/scorelab/ioe/domain/Subscription.java
@@ -21,6 +21,9 @@ public class Subscription implements Serializable {
     @Column(name = "subscription_id")
     private Long subscriptionId;
 
+    @Column(name = "topics")
+    private String topics;
+
     @ManyToOne
     private Device device;
 
@@ -44,6 +47,14 @@ public class Subscription implements Serializable {
 
     public void setSubscriptionId(Long subscriptionId) {
         this.subscriptionId = subscriptionId;
+    }
+
+    public String getTopics() {
+        return topics;
+    }
+
+    public void setTopics(String topics) {
+        this.topics = topics;
     }
 
     public Device getDevice() {
@@ -95,6 +106,7 @@ public class Subscription implements Serializable {
         return "Subscription{" +
             "id=" + id +
             ", subscriptionId='" + subscriptionId + "'" +
+            ", topics='" + topics + "'" +
             '}';
     }
 }

--- a/rest_api/src/main/webapp/app/entities/subscription/subscription-detail.html
+++ b/rest_api/src/main/webapp/app/entities/subscription/subscription-detail.html
@@ -8,6 +8,10 @@
         <dd>
             <span>{{vm.subscription.subscriptionId}}</span>
         </dd>
+        <dt><span translate="ioeApp.subscription.topics">Topics</span></dt>
+        <dd>
+            <span>{{vm.subscription.topics}}</span>
+        </dd>
         <dt><span translate="ioeApp.subscription.device">Device</span></dt>
         <dd>
             <a ui-sref="device-detail({id:vm.subscription.device.id})">{{vm.subscription.device.id}}</a>

--- a/rest_api/src/main/webapp/app/entities/subscription/subscription-detail.html
+++ b/rest_api/src/main/webapp/app/entities/subscription/subscription-detail.html
@@ -8,9 +8,9 @@
         <dd>
             <span>{{vm.subscription.subscriptionId}}</span>
         </dd>
-        <dt><span translate="ioeApp.subscription.topics">Topics</span></dt>
+        <dt><span translate="ioeApp.subscription.topicFilter">Topic Filter</span></dt>
         <dd>
-            <span>{{vm.subscription.topics}}</span>
+            <span>{{vm.subscription.topicFilter}}</span>
         </dd>
         <dt><span translate="ioeApp.subscription.device">Device</span></dt>
         <dd>

--- a/rest_api/src/main/webapp/app/entities/subscription/subscription-dialog.html
+++ b/rest_api/src/main/webapp/app/entities/subscription/subscription-dialog.html
@@ -19,6 +19,12 @@
                     ng-model="vm.subscription.subscriptionId"
                      />
         </div>
+        <div class="form-group">
+            <label class="control-label" translate="ioeApp.subscription.topics" for="field_topics">Topics</label>
+            <input type="text" class="form-control" name="topics" id="field_topics"
+                    ng-model="vm.subscription.topics"
+                     />
+        </div>
 
         <div class="form-group">
             <label translate="ioeApp.subscription.device" for="field_device">Device</label>

--- a/rest_api/src/main/webapp/app/entities/subscription/subscription-dialog.html
+++ b/rest_api/src/main/webapp/app/entities/subscription/subscription-dialog.html
@@ -20,9 +20,9 @@
                      />
         </div>
         <div class="form-group">
-            <label class="control-label" translate="ioeApp.subscription.topics" for="field_topics">Topics</label>
-            <input type="text" class="form-control" name="topics" id="field_topics"
-                    ng-model="vm.subscription.topics"
+            <label class="control-label" translate="ioeApp.subscription.topicFilter" for="field_topicFilter">Topic Filter</label>
+            <input type="text" class="form-control" name="topicFilter" id="field_topicFilter"
+                    ng-model="vm.subscription.topicFilter"
                      />
         </div>
 

--- a/rest_api/src/main/webapp/app/entities/subscription/subscription.state.js
+++ b/rest_api/src/main/webapp/app/entities/subscription/subscription.state.js
@@ -72,7 +72,7 @@
                         entity: function () {
                             return {
                                 subscriptionId: null,
-                                topics: null,
+                                topicFilter: null,
                                 id: null
                             };
                         }

--- a/rest_api/src/main/webapp/app/entities/subscription/subscription.state.js
+++ b/rest_api/src/main/webapp/app/entities/subscription/subscription.state.js
@@ -72,6 +72,7 @@
                         entity: function () {
                             return {
                                 subscriptionId: null,
+                                topics: null,
                                 id: null
                             };
                         }

--- a/rest_api/src/main/webapp/app/entities/subscription/subscriptions.html
+++ b/rest_api/src/main/webapp/app/entities/subscription/subscriptions.html
@@ -20,6 +20,7 @@
                 <tr>
                     <th><span translate="global.field.id">ID</span></th>
                     <th><span translate="ioeApp.subscription.subscriptionId">Subscription Id</span></th>
+                    <th><span translate="ioeApp.subscription.topics">Topics</span></th>
                     <th><span translate="ioeApp.subscription.device">Device</span></th>
                     <th><span translate="ioeApp.subscription.sensor">Sensor</span></th>
                     <th><span translate="ioeApp.subscription.user">User</span></th>
@@ -30,6 +31,7 @@
                 <tr ng-repeat="subscription in vm.subscriptions track by subscription.id">
                     <td><a ui-sref="subscription-detail({id:subscription.id})">{{subscription.id}}</a></td>
                     <td>{{subscription.subscriptionId}}</td>
+                    <td>{{subscription.topics}}</td>
                     <td>
                         <a ui-sref="device-detail({id:subscription.device.id})">{{subscription.device.id}}</a>
                     </td>

--- a/rest_api/src/main/webapp/app/entities/subscription/subscriptions.html
+++ b/rest_api/src/main/webapp/app/entities/subscription/subscriptions.html
@@ -20,7 +20,7 @@
                 <tr>
                     <th><span translate="global.field.id">ID</span></th>
                     <th><span translate="ioeApp.subscription.subscriptionId">Subscription Id</span></th>
-                    <th><span translate="ioeApp.subscription.topics">Topics</span></th>
+                    <th><span translate="ioeApp.subscription.topicFilter">Topic Filter</span></th>
                     <th><span translate="ioeApp.subscription.device">Device</span></th>
                     <th><span translate="ioeApp.subscription.sensor">Sensor</span></th>
                     <th><span translate="ioeApp.subscription.user">User</span></th>
@@ -31,7 +31,7 @@
                 <tr ng-repeat="subscription in vm.subscriptions track by subscription.id">
                     <td><a ui-sref="subscription-detail({id:subscription.id})">{{subscription.id}}</a></td>
                     <td>{{subscription.subscriptionId}}</td>
-                    <td>{{subscription.topics}}</td>
+                    <td>{{subscription.topicFilter}}</td>
                     <td>
                         <a ui-sref="device-detail({id:subscription.device.id})">{{subscription.device.id}}</a>
                     </td>

--- a/rest_api/src/main/webapp/i18n/en/subscription.json
+++ b/rest_api/src/main/webapp/i18n/en/subscription.json
@@ -17,7 +17,7 @@
                 "title": "Subscription"
             },
             "subscriptionId": "Subscription Id",
-            "topics": "Topics",
+            "topicFilter": "Topic Filter",
             "device": "Device",
             "sensor": "Sensor",
             "user": "User"

--- a/rest_api/src/main/webapp/i18n/en/subscription.json
+++ b/rest_api/src/main/webapp/i18n/en/subscription.json
@@ -17,6 +17,7 @@
                 "title": "Subscription"
             },
             "subscriptionId": "Subscription Id",
+            "topics": "Topics",
             "device": "Device",
             "sensor": "Sensor",
             "user": "User"

--- a/rest_api/src/test/gatling/simulations/SubscriptionGatlingTest.scala
+++ b/rest_api/src/test/gatling/simulations/SubscriptionGatlingTest.scala
@@ -68,7 +68,7 @@ class SubscriptionGatlingTest extends Simulation {
             .exec(http("Create new subscription")
             .post("/api/subscriptions")
             .headers(headers_http_authenticated)
-            .body(StringBody("""{"id":null, "subscriptionId":null}""")).asJSON
+            .body(StringBody("""{"id":null, "subscriptionId":null, "topics":"SAMPLE_TEXT"}""")).asJSON
             .check(status.is(201))
             .check(headerRegex("Location", "(.*)").saveAs("new_subscription_url"))).exitHereIfFailed
             .pause(10)

--- a/rest_api/src/test/gatling/simulations/SubscriptionGatlingTest.scala
+++ b/rest_api/src/test/gatling/simulations/SubscriptionGatlingTest.scala
@@ -68,7 +68,7 @@ class SubscriptionGatlingTest extends Simulation {
             .exec(http("Create new subscription")
             .post("/api/subscriptions")
             .headers(headers_http_authenticated)
-            .body(StringBody("""{"id":null, "subscriptionId":null, "topics":"SAMPLE_TEXT"}""")).asJSON
+            .body(StringBody("""{"id":null, "subscriptionId":null, "topicFilter":"SAMPLE_TEXT"}""")).asJSON
             .check(status.is(201))
             .check(headerRegex("Location", "(.*)").saveAs("new_subscription_url"))).exitHereIfFailed
             .pause(10)

--- a/rest_api/src/test/java/com/scorelab/ioe/web/rest/SubscriptionResourceIntTest.java
+++ b/rest_api/src/test/java/com/scorelab/ioe/web/rest/SubscriptionResourceIntTest.java
@@ -44,6 +44,8 @@ public class SubscriptionResourceIntTest {
 
     private static final Long DEFAULT_SUBSCRIPTION_ID = 1L;
     private static final Long UPDATED_SUBSCRIPTION_ID = 2L;
+    private static final String DEFAULT_TOPICS = "AAAAA";
+    private static final String UPDATED_TOPICS = "BBBBB";
 
     @Inject
     private SubscriptionRepository subscriptionRepository;
@@ -72,6 +74,7 @@ public class SubscriptionResourceIntTest {
     public void initTest() {
         subscription = new Subscription();
         subscription.setSubscriptionId(DEFAULT_SUBSCRIPTION_ID);
+        subscription.setTopics(DEFAULT_TOPICS);
     }
 
     @Test
@@ -91,6 +94,7 @@ public class SubscriptionResourceIntTest {
         assertThat(subscriptions).hasSize(databaseSizeBeforeCreate + 1);
         Subscription testSubscription = subscriptions.get(subscriptions.size() - 1);
         assertThat(testSubscription.getSubscriptionId()).isEqualTo(DEFAULT_SUBSCRIPTION_ID);
+        assertThat(testSubscription.getTopics()).isEqualTo(DEFAULT_TOPICS);
     }
 
     @Test
@@ -104,7 +108,8 @@ public class SubscriptionResourceIntTest {
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.[*].id").value(hasItem(subscription.getId().intValue())))
-                .andExpect(jsonPath("$.[*].subscriptionId").value(hasItem(DEFAULT_SUBSCRIPTION_ID.intValue())));
+                .andExpect(jsonPath("$.[*].subscriptionId").value(hasItem(DEFAULT_SUBSCRIPTION_ID.intValue())))
+                .andExpect(jsonPath("$.[*].topics").value(hasItem(DEFAULT_TOPICS.toString())));
     }
 
     @Test
@@ -118,7 +123,8 @@ public class SubscriptionResourceIntTest {
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.id").value(subscription.getId().intValue()))
-            .andExpect(jsonPath("$.subscriptionId").value(DEFAULT_SUBSCRIPTION_ID.intValue()));
+            .andExpect(jsonPath("$.subscriptionId").value(DEFAULT_SUBSCRIPTION_ID.intValue()))
+            .andExpect(jsonPath("$.topics").value(DEFAULT_TOPICS.toString()));
     }
 
     @Test
@@ -140,6 +146,7 @@ public class SubscriptionResourceIntTest {
         Subscription updatedSubscription = new Subscription();
         updatedSubscription.setId(subscription.getId());
         updatedSubscription.setSubscriptionId(UPDATED_SUBSCRIPTION_ID);
+        updatedSubscription.setTopics(UPDATED_TOPICS);
 
         restSubscriptionMockMvc.perform(put("/api/subscriptions")
                 .contentType(TestUtil.APPLICATION_JSON_UTF8)
@@ -151,6 +158,7 @@ public class SubscriptionResourceIntTest {
         assertThat(subscriptions).hasSize(databaseSizeBeforeUpdate);
         Subscription testSubscription = subscriptions.get(subscriptions.size() - 1);
         assertThat(testSubscription.getSubscriptionId()).isEqualTo(UPDATED_SUBSCRIPTION_ID);
+        assertThat(testSubscription.getTopics()).isEqualTo(UPDATED_TOPICS);
     }
 
     @Test

--- a/rest_api/src/test/java/com/scorelab/ioe/web/rest/SubscriptionResourceIntTest.java
+++ b/rest_api/src/test/java/com/scorelab/ioe/web/rest/SubscriptionResourceIntTest.java
@@ -44,8 +44,8 @@ public class SubscriptionResourceIntTest {
 
     private static final Long DEFAULT_SUBSCRIPTION_ID = 1L;
     private static final Long UPDATED_SUBSCRIPTION_ID = 2L;
-    private static final String DEFAULT_TOPICS = "AAAAA";
-    private static final String UPDATED_TOPICS = "BBBBB";
+    private static final String DEFAULT_TOPIC_FILTER = "AAAAA";
+    private static final String UPDATED_TOPIC_FILTER = "BBBBB";
 
     @Inject
     private SubscriptionRepository subscriptionRepository;
@@ -74,7 +74,7 @@ public class SubscriptionResourceIntTest {
     public void initTest() {
         subscription = new Subscription();
         subscription.setSubscriptionId(DEFAULT_SUBSCRIPTION_ID);
-        subscription.setTopics(DEFAULT_TOPICS);
+        subscription.setTopicFilter(DEFAULT_TOPIC_FILTER);
     }
 
     @Test
@@ -94,7 +94,7 @@ public class SubscriptionResourceIntTest {
         assertThat(subscriptions).hasSize(databaseSizeBeforeCreate + 1);
         Subscription testSubscription = subscriptions.get(subscriptions.size() - 1);
         assertThat(testSubscription.getSubscriptionId()).isEqualTo(DEFAULT_SUBSCRIPTION_ID);
-        assertThat(testSubscription.getTopics()).isEqualTo(DEFAULT_TOPICS);
+        assertThat(testSubscription.getTopicFilter()).isEqualTo(DEFAULT_TOPIC_FILTER);
     }
 
     @Test
@@ -109,7 +109,7 @@ public class SubscriptionResourceIntTest {
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.[*].id").value(hasItem(subscription.getId().intValue())))
                 .andExpect(jsonPath("$.[*].subscriptionId").value(hasItem(DEFAULT_SUBSCRIPTION_ID.intValue())))
-                .andExpect(jsonPath("$.[*].topics").value(hasItem(DEFAULT_TOPICS.toString())));
+                .andExpect(jsonPath("$.[*].topicFilter").value(hasItem(DEFAULT_TOPIC_FILTER.toString())));
     }
 
     @Test
@@ -124,7 +124,7 @@ public class SubscriptionResourceIntTest {
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))
             .andExpect(jsonPath("$.id").value(subscription.getId().intValue()))
             .andExpect(jsonPath("$.subscriptionId").value(DEFAULT_SUBSCRIPTION_ID.intValue()))
-            .andExpect(jsonPath("$.topics").value(DEFAULT_TOPICS.toString()));
+            .andExpect(jsonPath("$.topicFilter").value(DEFAULT_TOPIC_FILTER.toString()));
     }
 
     @Test
@@ -146,7 +146,7 @@ public class SubscriptionResourceIntTest {
         Subscription updatedSubscription = new Subscription();
         updatedSubscription.setId(subscription.getId());
         updatedSubscription.setSubscriptionId(UPDATED_SUBSCRIPTION_ID);
-        updatedSubscription.setTopics(UPDATED_TOPICS);
+        updatedSubscription.setTopicFilter(UPDATED_TOPIC_FILTER);
 
         restSubscriptionMockMvc.perform(put("/api/subscriptions")
                 .contentType(TestUtil.APPLICATION_JSON_UTF8)
@@ -158,7 +158,7 @@ public class SubscriptionResourceIntTest {
         assertThat(subscriptions).hasSize(databaseSizeBeforeUpdate);
         Subscription testSubscription = subscriptions.get(subscriptions.size() - 1);
         assertThat(testSubscription.getSubscriptionId()).isEqualTo(UPDATED_SUBSCRIPTION_ID);
-        assertThat(testSubscription.getTopics()).isEqualTo(UPDATED_TOPICS);
+        assertThat(testSubscription.getTopicFilter()).isEqualTo(UPDATED_TOPIC_FILTER);
     }
 
     @Test


### PR DESCRIPTION
Topic field is added to subscription entity so that user can create subscriptions to topics. Only those sensor data with topics specified in the subscription will be retrieved in the device. This allows the user to retrieve only required sensor data rather than retrieving all data stored by the device. 