### PR TITLE
Publish-subscribe using message broker

### DIFF
--- a/rest_api/src/main/java/com/scorelab/ioe/broker/BrokerProducerThread.java
+++ b/rest_api/src/main/java/com/scorelab/ioe/broker/BrokerProducerThread.java
@@ -1,0 +1,76 @@
+package com.scorelab.ioe.broker;
+
+import javax.jms.*;
+
+import com.scorelab.ioe.config.IoeConfiguration;
+import com.scorelab.ioe.repository.SensorRepository;
+import com.scorelab.ioe.service.SensorDataRepositoryService;
+import com.scorelab.ioe.repository.PublicationRepository;
+import com.scorelab.ioe.domain.Publication;
+import org.apache.activemq.artemis.api.jms.ActiveMQJMSClient;
+import org.apache.activemq.artemis.jms.client.ActiveMQConnectionFactory;
+
+import java.util.List;
+
+/**
+ * Created by priya on 22/6/17.
+ */
+
+public class BrokerProducerThread implements Runnable {
+    private Thread t;
+
+    private SensorRepository sensorRepository;
+    private SensorDataRepositoryService databaseService;
+    private IoeConfiguration ioeConfiguration;
+    private PublicationRepository publicationRepository;
+
+    public BrokerProducerThread(SensorRepository sensorRepository, SensorDataRepositoryService databaseService, IoeConfiguration ioeConfiguration, PublicationRepository publicationRepository) {
+        this.sensorRepository = sensorRepository;
+        this.databaseService = databaseService;
+        this.ioeConfiguration = ioeConfiguration;
+        this.publicationRepository = publicationRepository;
+    }
+
+    public void StartBrokerProducer() throws JMSException {
+
+        Connection connection = null;
+        try {
+            ConnectionFactory cf = new ActiveMQConnectionFactory(ioeConfiguration.getTopic().getTopicUrl());
+            connection = cf.createConnection(ioeConfiguration.getTopic().getUsername(), ioeConfiguration.getTopic().getPassword());
+            Session session = connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+
+            // TODO - Read message payload from cassandra
+            String payload = "{\"data\": \"36\",\"description\": \"test\",\"sensorId\": 1, \"timestamp\": \"2015-06-19T11:07:44.526Z\", \"topic\": \"topic\"}";
+            Message msg = session.createTextMessage(payload);
+
+            //TODO Read topic value from the sensor data or publication entity
+            Topic topic = ActiveMQJMSClient.createTopic("ioe");
+            MessageProducer messageProducer = session.createProducer(null);
+            messageProducer.send(topic,msg);
+            connection.start();
+        } catch (Exception ex) {
+            ex.printStackTrace();
+        }
+    }
+
+    @Override
+    public void run() {
+        try {
+            StartBrokerProducer();
+            while (true) {
+                Thread.sleep(1000);
+            }
+        } catch (JMSException e) {
+            e.printStackTrace();
+        } catch (InterruptedException e) {
+            System.out.println("Message broker thread interrupted.");
+        }
+    }
+
+    public void start() {
+        if (t == null) {
+            t = new Thread(this);
+            t.start();
+        }
+    }
+}

--- a/rest_api/src/main/java/com/scorelab/ioe/broker/ContextRefreshedListener.java
+++ b/rest_api/src/main/java/com/scorelab/ioe/broker/ContextRefreshedListener.java
@@ -3,6 +3,7 @@ package com.scorelab.ioe.broker;
 import com.scorelab.ioe.config.IoeConfiguration;
 import com.scorelab.ioe.repository.SensorRepository;
 import com.scorelab.ioe.service.SensorDataRepositoryService;
+import com.scorelab.ioe.repository.SubscriptionRepository;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.ApplicationListener;
@@ -30,8 +31,11 @@ public class ContextRefreshedListener implements ApplicationListener<ContextRefr
     @Autowired
     private SensorDataRepositoryService databaseService;
 
+    @Autowired
+    private SubscriptionRepository subscriptionRepository;
+
     @Override
     public void onApplicationEvent(ContextRefreshedEvent contextRefreshedEvent) {
-        taskExecutor.execute(new BrokerConsumerThread(sensorRepository, databaseService, ioeConfiguration));
+        taskExecutor.execute(new BrokerConsumerThread(sensorRepository, databaseService, ioeConfiguration, subscriptionRepository));
     }
 }

--- a/rest_api/src/main/java/com/scorelab/ioe/broker/ContextRefreshedListener.java
+++ b/rest_api/src/main/java/com/scorelab/ioe/broker/ContextRefreshedListener.java
@@ -36,6 +36,6 @@ public class ContextRefreshedListener implements ApplicationListener<ContextRefr
 
     @Override
     public void onApplicationEvent(ContextRefreshedEvent contextRefreshedEvent) {
-        taskExecutor.execute(new BrokerConsumerThread(sensorRepository, databaseService, ioeConfiguration, subscriptionRepository));
+        taskExecutor.execute(new MqttConsumerThread(sensorRepository, databaseService, ioeConfiguration, subscriptionRepository));
     }
 }

--- a/rest_api/src/main/java/com/scorelab/ioe/broker/EventPublisher.java
+++ b/rest_api/src/main/java/com/scorelab/ioe/broker/EventPublisher.java
@@ -1,0 +1,42 @@
+package com.scorelab.ioe.broker;
+
+import com.scorelab.ioe.config.IoeConfiguration;
+import com.scorelab.ioe.repository.SensorRepository;
+import com.scorelab.ioe.service.SensorDataRepositoryService;
+import com.scorelab.ioe.repository.PublicationRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.context.ApplicationEventPublisherAware;
+
+import org.springframework.core.task.TaskExecutor;
+import org.springframework.stereotype.Component;
+
+/**
+ * Created by priya on 22/6/17.
+ */
+
+@Component
+public class EventPublisher implements ApplicationEventPublisherAware{
+
+    @Autowired
+    @Qualifier("taskExecutor")
+    private TaskExecutor taskExecutor;
+
+    @Autowired
+    private SensorRepository sensorRepository;
+
+    @Autowired
+    private IoeConfiguration ioeConfiguration;
+
+    @Autowired
+    private SensorDataRepositoryService databaseService;
+
+    @Autowired
+    private PublicationRepository publicationRepository;
+
+    @Override
+    public void setApplicationEventPublisher(ApplicationEventPublisher publisher) {
+        taskExecutor.execute(new BrokerProducerThread(sensorRepository, databaseService, ioeConfiguration, publicationRepository));
+    }
+}

--- a/rest_api/src/main/java/com/scorelab/ioe/broker/MqttConsumerThread.java
+++ b/rest_api/src/main/java/com/scorelab/ioe/broker/MqttConsumerThread.java
@@ -1,41 +1,96 @@
 package com.scorelab.ioe.broker;
 
+
 import com.scorelab.ioe.config.Constants;
 import com.scorelab.ioe.config.IoeConfiguration;
 import com.scorelab.ioe.repository.SubscriptionRepository;
 import com.scorelab.ioe.domain.Subscription;
+import com.scorelab.ioe.domain.Sensor;
+import com.scorelab.ioe.domain.SensorData;
+import com.scorelab.ioe.nosql.StoreTypes;
+import com.scorelab.ioe.repository.SensorRepository;
+import com.scorelab.ioe.service.SensorDataRepositoryService;
+
 import org.fusesource.mqtt.client.BlockingConnection;
 import org.fusesource.mqtt.client.MQTT;
 import org.fusesource.mqtt.client.QoS;
 import org.fusesource.mqtt.client.Topic;
+import org.fusesource.mqtt.client.Message;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import com.fatboyindustrial.gsonjavatime.Converters;
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.JsonIOException;
+import com.google.gson.JsonSyntaxException;
+
 
 import java.util.List;
 import java.util.ArrayList;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
 
 import java.net.URISyntaxException;
 
 /**
  * Created by tharidu on 8/4/16.
  */
-public class MqttConsumerThread {
+public class MqttConsumerThread implements Runnable{
 
     @Autowired
     private IoeConfiguration ioeConfiguration;
     private SubscriptionRepository subscriptionRepository;
+    private Gson gson;
+    private SensorRepository sensorRepository;
+    private SensorDataRepositoryService databaseService;
+
+    public MqttConsumerThread(SensorRepository sensorRepository, SensorDataRepositoryService databaseService, IoeConfiguration ioeConfiguration, SubscriptionRepository subscriptionRepository) {
+        this.ioeConfiguration = ioeConfiguration;
+        this.subscriptionRepository = subscriptionRepository;
+        this.sensorRepository = sensorRepository;
+        this.databaseService = databaseService;
+        gson = Converters.registerAll(new GsonBuilder()).create();
+    }
 
     public void StartBrokerConsumer() throws Exception {
         MQTT mqtt = new MQTT();
         mqtt.setHost(ioeConfiguration.getTopic().getMqttUrl());
         BlockingConnection connection = mqtt.blockingConnection();
         connection.connect();
-
         List<Topic> topic_list = new ArrayList<>();
-        List<Subscription> subscriptions = subscriptionRepository.findAll();
-        for (Subscription s : subscriptions) {
-            topic_list.add(new Topic(s.getTopicFilter(), QoS.AT_LEAST_ONCE));
+
+        while (true) {
+            List<Subscription> subscriptions = subscriptionRepository.findAll();
+            for (Subscription s : subscriptions) {
+                topic_list.add(new Topic(s.getTopicFilter(), QoS.AT_LEAST_ONCE));
+            }
+            Topic[] topics = topic_list.toArray(new Topic[topic_list.size()]);
+            connection.subscribe(topics);
+
+            Message message = connection.receive();
+            byte[] payload = message.getPayload();
+            String messageContent = new String(payload);
+            SensorData sensorData = gson.fromJson(messageContent, SensorData.class);
+            ZonedDateTime utcTime = sensorData.getTimestamp().withZoneSameInstant(ZoneOffset.UTC);
+            Sensor sensor = sensorRepository.findBySensorId(sensorData.getSensorId());
+            // TODO - Read TTL value
+            databaseService.insertData(sensorData.getSensorId(), sensorData.getData(), sensorData.getDescription(), utcTime, StoreTypes.valueOf(sensor.getStoreType()), sensorData.getTopic(), 0);
+            System.out.println("Received message: " + messageContent);
+            message.ack();
         }
-        Topic[] topics = topic_list.toArray(new Topic[topic_list.size()]);
-        connection.subscribe(topics);
     }
+
+    @Override
+    public void run() {
+        try {
+            StartBrokerConsumer();
+            while (true) {
+                Thread.sleep(1000);
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+
 }

--- a/rest_api/src/main/java/com/scorelab/ioe/broker/MqttConsumerThread.java
+++ b/rest_api/src/main/java/com/scorelab/ioe/broker/MqttConsumerThread.java
@@ -18,7 +18,7 @@ public class MqttConsumerThread {
 
     public void StartBrokerConsumer() throws Exception {
         MQTT mqtt = new MQTT();
-        mqtt.setHost(ioeConfiguration.getQueue().getMqttUrl());
+        mqtt.setHost(ioeConfiguration.getTopic().getMqttUrl());
         BlockingConnection connection = mqtt.blockingConnection();
         connection.connect();
 

--- a/rest_api/src/main/java/com/scorelab/ioe/broker/MqttConsumerThread.java
+++ b/rest_api/src/main/java/com/scorelab/ioe/broker/MqttConsumerThread.java
@@ -2,9 +2,16 @@ package com.scorelab.ioe.broker;
 
 import com.scorelab.ioe.config.Constants;
 import com.scorelab.ioe.config.IoeConfiguration;
+import com.scorelab.ioe.repository.SubscriptionRepository;
+import com.scorelab.ioe.domain.Subscription;
 import org.fusesource.mqtt.client.BlockingConnection;
 import org.fusesource.mqtt.client.MQTT;
+import org.fusesource.mqtt.client.QoS;
+import org.fusesource.mqtt.client.Topic;
 import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+import java.util.ArrayList;
 
 import java.net.URISyntaxException;
 
@@ -15,6 +22,7 @@ public class MqttConsumerThread {
 
     @Autowired
     private IoeConfiguration ioeConfiguration;
+    private SubscriptionRepository subscriptionRepository;
 
     public void StartBrokerConsumer() throws Exception {
         MQTT mqtt = new MQTT();
@@ -22,5 +30,12 @@ public class MqttConsumerThread {
         BlockingConnection connection = mqtt.blockingConnection();
         connection.connect();
 
+        List<Topic> topic_list = new ArrayList<>();
+        List<Subscription> subscriptions = subscriptionRepository.findAll();
+        for (Subscription s : subscriptions) {
+            topic_list.add(new Topic(s.getTopicFilter(), QoS.AT_LEAST_ONCE));
+        }
+        Topic[] topics = topic_list.toArray(new Topic[topic_list.size()]);
+        connection.subscribe(topics);
     }
 }

--- a/rest_api/src/main/java/com/scorelab/ioe/config/IoeConfiguration.java
+++ b/rest_api/src/main/java/com/scorelab/ioe/config/IoeConfiguration.java
@@ -10,14 +10,14 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 public class IoeConfiguration {
 
     private final Cassandra cassandra = new Cassandra();
-    private final Queue queue = new Queue();
+    private final Topic topic = new Topic();
 
     public Cassandra getCassandra() {
         return cassandra;
     }
 
-    public Queue getQueue() {
-        return queue;
+    public Topic getTopic() {
+        return topic;
     }
 
     public static class Cassandra {
@@ -51,27 +51,27 @@ public class IoeConfiguration {
         }
     }
 
-    public static class Queue {
-        private String queueName = "ioeQueue";
-        private String queueUrl = "tcp://localhost:61616";
+    public static class Topic {
+        private String topicName = "ioe";
+        private String topicUrl = "tcp://localhost:61616";
         private String mqttUrl = "tcp://localhost:61616";
         private String username;
         private String password;
 
-        public String getQueueName() {
-            return queueName;
+        public String getTopicName() {
+            return topicName;
         }
 
-        public void setQueueName(String queueName) {
-            this.queueName = queueName;
+        public void setTopicName(String topicName) {
+            this.topicName = topicName;
         }
 
-        public String getQueueUrl() {
-            return queueUrl;
+        public String getTopicUrl() {
+            return topicUrl;
         }
 
-        public void setQueueUrl(String queueUrl) {
-            this.queueUrl = queueUrl;
+        public void setTopicUrl(String topicUrl) {
+            this.topicUrl = topicUrl;
         }
 
         public String getMqttUrl() {

--- a/rest_api/src/main/resources/config/application.yml
+++ b/rest_api/src/main/resources/config/application.yml
@@ -84,9 +84,9 @@ ioe:
         cassandraKeyspace: ioe
         strategy: SimpleStrategy
         replicationFactor: 1
-    queue:
-        queueName: ioeQueue
-        queueUrl: tcp://broker:61616
-        mqttUrl: tcp://broker:61616
+    topic:
+        topicName: ioe
+        topicUrl: tcp://localhost:61616
+        mqttUrl: tcp://localhost:61616
         username: artemis
         password: simetraehcapa


### PR DESCRIPTION
The topic is created in BrokerConsumerThread using value of topicFilter field from subscriptions table and consumer is created for each topic. The queue is replaced with topic to support publish-subscribe behavior. The producer is created in BrokerProducer thread to publish the message to topics.