### PR TITLE
Corrected the Gitter link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-[![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/cloudlibz/cloudlibz)
+[![Gitter](https://img.shields.io/gitter/room/nwjs/nw.js.svg)](https://gitter.im/scorelab/scorelab)
 [![Build Status](https://travis-ci.org/scorelab/OpenIoE.svg?branch=master)](https://travis-ci.org/scorelab/OpenIoE)
 [![GitHub license](https://img.shields.io/badge/License-Apache%202.0-blue.svg)](https://raw.githubusercontent.com/scorelab/OpenIoE/master/LICENSE)
 [![Codacy Badge](https://api.codacy.com/project/badge/Grade/52edea34ff8943768a8c5a62728f73a7)](https://www.codacy.com/app/hcktheheaven/clocal-gcp?utm_source=github.com&amp;utm_medium=referral&amp;utm_content=hcktheheaven/clocal-gcp&amp;utm_campaign=Badge_Grade)


### PR DESCRIPTION
Fixes - #65 
The wrong hyperlink in the README has been changed to the correct Scorelab Gitter chat (https://gitter.im/scorelab/scorelab)